### PR TITLE
fix: properly handle urls with parameters

### DIFF
--- a/src/services/meme.ts
+++ b/src/services/meme.ts
@@ -28,11 +28,11 @@ export class MemeService {
     const body = ctx.request.body as { url: string };
     const url = body.url;
 
-    const PICTURE_EXTENSIONS = ["png", "jpg", "jpeg", "apng"];
+    const PICTURE_EXTENSIONS = ["png", "jpg", "jpeg", "apng", "webp"];
     const VIDEO_EXTENSIONS = ["mp4", "webm"];
     const GIF_EXTENSIONS = ["gif"];
 
-    const fileExt = url.split(".").at(-1)?.trim();
+    const fileExt = url.split(".").pop()?.split("?")[0].trim();
 
     if (!fileExt) {
       ctx.status = 400;


### PR DESCRIPTION
This pull request fixes the issue where urls with parameters (such as `example.com/cat.jpg?meow=true`) will be properly handled by the upload route. previously, it would error because it would not get the correct url extension in these cases. I also added webp as an option